### PR TITLE
fix(editor): Add missing UnityEngine using directive to fix GitHub Actions build failure

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Editor/Initialization/RestartUnityEditorAfterPackageInstallation.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/Initialization/RestartUnityEditorAfterPackageInstallation.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using UnityEditor;
 using UnityEditor.PackageManager;
+using UnityEngine;
 
 /// <summary>
 /// Restart Unity Editor after package installation


### PR DESCRIPTION
## Summary
This PR fixes the GitHub Actions build failure caused by a missing `using UnityEngine;` directive.

## Problem
The `RestartUnityEditorAfterPackageInstallation.cs` file uses `Application.isBatchMode` on line 14, but the file was missing the required `using UnityEngine;` import statement.

This caused the following compiler error in CI/CD builds:
```
error CS0103: The name 'Application' does not exist in the current context
```

## Solution
Added the missing `using UnityEngine;` directive to the file.

## Changes
- Added `using UnityEngine;` to `Packages/com.styly.styly-xr-rig/Editor/Initialization/RestartUnityEditorAfterPackageInstallation.cs`

## Testing
This change should fix the following failed workflow runs:
- Build Meta OpenXR (Quest) - Run #20819309265
- Build PICO Unity OpenXR - Run #20819309243
