### PR TITLE
fix(ci): Add two-step workflow support for CI/CD builds

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -74,6 +74,33 @@ GitHub Actionsを実行するには、以下のシークレットをリポジト
 2. 必要なシーンがBuild Settingsに含まれているか確認
 3. ワークフローログで詳細なエラーメッセージを確認
 
+### Prefab Variant parent missing エラーの場合
+
+`STYLY XR Rig.prefab` は XR Interaction Toolkit の「Hands Interaction Demo」サンプルに含まれる `XR Origin Hands (XR Rig)` プレハブの Prefab Variant です。このサンプルは通常 Unity エディタで自動的にインストールされますが、CI/CD環境ではインストールされないため、ビルドが失敗することがあります。
+
+**解決方法**: ワークフローを2段階に分けて、まずサンプルをインストールしてからビルドを実行します。
+
+```yaml
+# Step 1: Install required samples
+- name: Install Required Samples
+  uses: game-ci/unity-builder@v4
+  env:
+    UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+    UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+  with:
+    targetPlatform: Android
+    unityVersion: 6000.0.59f2
+    buildMethod: Styly.XRRig.Initialization.CISampleInstaller.InstallSamplesAndExit
+
+# Step 2: Build the project (samples are now installed)
+- name: Build Unity Project
+  uses: game-ci/unity-builder@v4
+  # ... (your existing build configuration)
+```
+
+`CISampleInstaller.InstallSamplesAndExit` メソッドは、`required_samples.json` に記載された全てのサンプルをインストールし、その後Unityを終了します。
+
 ### Unity Licenseの取得方法
 
 GameCIの公式ドキュメントを参照してください：

--- a/Packages/com.styly.styly-xr-rig/Editor/Initialization/CISampleInstaller.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/Initialization/CISampleInstaller.cs
@@ -17,6 +17,40 @@ namespace Styly.XRRig.Initialization
         private static readonly string RequiredSamplesJson = "required_samples.json";
 
         /// <summary>
+        /// Entry point for CI/CD to install samples and exit.
+        /// This method can be called from command line via -executeMethod
+        /// 
+        /// Usage in GitHub Actions workflow:
+        /// <code>
+        /// - name: Install Required Samples
+        ///   uses: game-ci/unity-builder@v4
+        ///   with:
+        ///     buildMethod: Styly.XRRig.Initialization.CISampleInstaller.InstallSamplesAndExit
+        /// </code>
+        /// 
+        /// This should be called as a separate step BEFORE the main build step to ensure
+        /// that all required samples (e.g., XR Interaction Toolkit's "Hands Interaction Demo")
+        /// are installed before Unity attempts to import prefabs that depend on them.
+        /// </summary>
+        public static void InstallSamplesAndExit()
+        {
+            Debug.Log("=== CI Sample Installer: Starting sample installation ===");
+            
+            try
+            {
+                InstallRequiredSamplesForCI();
+                Debug.Log("=== CI Sample Installer: Sample installation completed successfully ===");
+                EditorApplication.Exit(0);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"=== CI Sample Installer: Sample installation failed: {e.Message} ===");
+                Debug.LogError(e.StackTrace);
+                EditorApplication.Exit(1);
+            }
+        }
+
+        /// <summary>
         /// Install all required package samples for CI/CD build.
         /// This method runs synchronously and is designed to work in batch mode.
         /// </summary>


### PR DESCRIPTION
## Summary
This PR adds the necessary infrastructure for fixing the GitHub Actions build failures caused by missing prefab dependencies.

## Problem
The CI/CD builds are failing with the error:
```
Prefab Variant problem. Missing Prefab Variant parent: 'STYLY XR Rig (Missing Prefab with guid: d6878e1999eb4b44a9f5a263af86c185)'
```

## Root Cause
- `STYLY XR Rig.prefab` is a Prefab Variant based on the `XR Origin Hands (XR Rig)` prefab from the XR Interaction Toolkit's "Hands Interaction Demo" sample
- `InstallRequiredSamples.cs` skips sample installation in batch mode (CI/CD)
- Unity imports all assets BEFORE executing the build method, so the prefab import error occurs before any code can run

## Solution
This PR provides the infrastructure needed to fix the issue:

1. **Added `InstallSamplesAndExit()` method** - A dedicated entry point that can be called as a separate workflow step
2. **Updated `.github/README.md`** - Added troubleshooting guide with example workflow configuration

## Required Manual Step
⚠️ **The workflow files need to be updated manually** because GitHub Apps don't have permission to modify workflow files.

Please update `.github/workflows/build-meta-openxr.yml` and `.github/workflows/build-pico-openxr.yml` to add a sample installation step BEFORE the build step:

```yaml
# Step 1: Install required samples
- name: Install Required Samples
  uses: game-ci/unity-builder@v4
  env:
    UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
    UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
    UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
  with:
    targetPlatform: Android
    unityVersion: 6000.0.59f2
    buildMethod: Styly.XRRig.Initialization.CISampleInstaller.InstallSamplesAndExit

# Step 2: Build the project (existing step)
- name: Build Unity Project
  # ... existing configuration ...
```

## Changes
- `Editor/Initialization/CISampleInstaller.cs` - Added `InstallSamplesAndExit()` entry point
- `.github/README.md` - Added troubleshooting documentation